### PR TITLE
API key disabled for now with proper notify me option

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -653,27 +653,25 @@
                         </div>
                     </div>
 
-                    <!-- API Access -->
+                    <!-- API Access (Coming Soon) -->
                     <div class="profile-card">
                         <div class="card-header">
                             <h3><i class="fas fa-key"></i> API Access</h3>
+                            <span style="background: var(--accent-purple); color: #fff; font-size: 12px; padding: 4px 10px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.05em;">Coming Soon</span>
                         </div>
                         <div class="card-body">
-                            <p class="card-description">Use API keys to integrate Link360 with your applications</p>
-                            <div class="api-key-section">
-                                <div class="form-group">
-                                    <label>API Key</label>
-                                    <div class="input-with-action">
-                                        <input type="password" class="form-input" value="zpl_1234567890abcdef" readonly id="apiKeyInput">
-                                        <button class="btn btn-secondary btn-sm" id="toggleApiKey">
-                                            <i class="fas fa-eye"></i>
-                                        </button>
-                                        <button class="btn btn-secondary btn-sm" id="copyApiKey">
-                                            <i class="fas fa-copy"></i>
-                                        </button>
-                                    </div>
-                                </div>
-                                <button class="btn btn-danger btn-sm">Regenerate API Key</button>
+                            <p class="card-description">Premium API integrations, secure tokens, and rate-limited access are on the way.</p>
+                            <ul style="margin: 16px 0 20px 20px; color: var(--text-secondary); line-height: 1.6;">
+                                <li>Programmatic link creation & analytics sync</li>
+                                <li>Team-level API tokens with role controls</li>
+                                <li>Enterprise-grade rate limits & webhooks</li>
+                            </ul>
+                            <div style="padding: 16px; border-radius: 12px; background: rgba(139, 92, 246, 0.08); border: 1px dashed rgba(139, 92, 246, 0.3);">
+                                <h4 style="margin: 0 0 8px 0; font-size: 15px; color: var(--text-primary);">Available with Link360 Premium</h4>
+                                <p style="margin: 0 0 12px 0; font-size: 14px; color: var(--text-secondary);">Sign up to be the first to know when early access opens.</p>
+                                <button class="btn btn-secondary" style="width: 100%;" disabled>
+                                    <i class="fas fa-bell"></i> Notify Me When Ready
+                                </button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This pull request updates the "API Access" section of the public profile page to indicate that API features are not yet available and are coming soon. The previous API key management UI has been replaced with a preview of upcoming features and a notification signup prompt.

API Access section redesign:

* Replaces the existing API key management interface with a "Coming Soon" label and a description of planned API features, such as programmatic link creation, team-level tokens, and enterprise-grade rate limits.
* Adds a disabled "Notify Me When Ready" button for users to express interest in early access to the API features.

closes issues #5 